### PR TITLE
lint --fix npm script

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "prebuild": "npm run lint && npm run test && rimraf dist/*",
     "build": "webpack --progress --env",
     "lint": "eslint src tools",
+    "lintf": "eslint src tools --fix",
     "test:base": "mocha --compilers js:babel-register tools/test.js src/**/*.spec.js tools/**/*.spec.js",
     "test": "npm run test:base -- --reporter spec",
     "test:watch": "npm run test:base -- --reporter min --watch",


### PR DESCRIPTION
NEdával bych --fix do defaultního lint tasku, protože třeba můžem chtít aby lint pouštělo bamboo/cokoli, a nechceme aby to případně udělalo změny v kódu. Proto k "npm run lint" přidávám možnost "npm run lintf"